### PR TITLE
removing import mapping for go and cli

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoClientCodegen.java
@@ -113,7 +113,7 @@ public class GoClientCodegen extends AbstractGoCodegen {
         importMapping = new HashMap<String, String>();
         importMapping.put("time.Time", "time");
         importMapping.put("*os.File", "os");
-        importMapping.put("os", "io/ioutil");
+
         cliOptions.clear();
         cliOptions.add(new CliOption(CodegenConstants.PACKAGE_NAME, "Go package name (convention: lowercase).")
                 .defaultValue("swagger"));


### PR DESCRIPTION
Package io/util implements some I/O utility functions. As of Go 1.16, the same functionality is now provided by package os. so no need for import mapping. This issue was causing an unused import error.