### PR TITLE
fixing go sdk

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoClientCodegen.java
@@ -363,15 +363,7 @@ public class GoClientCodegen extends AbstractGoCodegen {
                 iterator.remove();
             }
         }
-        // if the return type is not primitive, import encoding/json
-        for (CodegenOperation operation : operations) {
-            if(operation.returnBaseType != null && needToImport(operation.returnBaseType)) {
-                Map<String, String> customImport = new HashMap<String, String>();
-                customImport.put("import", "encoding/json");
-                imports.add(customImport);
-                break; //just need to import once
-            }
-        }
+
         // recursivly add import for mapping one type to multipe imports
         List<Map<String, String>> recursiveImports = (List<Map<String, String>>) objs.get("imports");
         if (recursiveImports == null) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PureCloudGoClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PureCloudGoClientCodegen.java
@@ -174,6 +174,9 @@ public class PureCloudGoClientCodegen extends GoClientCodegen {
         if (property.name.equals("Type")) {
             property.name = escapeReservedWord(property.name);
         }
+        if (property.dataType.equals("[]Object")) {
+            property.dataType = "[]map[string]interface{}";
+        }
     }
 
     private void markRecursiveProperties(CodegenModel cm, CodegenProperty[] lineage) {


### PR DESCRIPTION
removing logic for adding encoding/json package to the imports list. This logic only adds the encoding/json package to the imports list if at least one of an apis operations returns a non-primitive type i.e model (which is most apis). The issue here is that there is an api with two operations that only return strings (no models), so the encoding/json package is never added to the imports list. this leads to an undefined error in the api file because there is a block of code defined in this file for checking if a return type is a string or not.
```
if "{{{returnType}}}" == "string" {
	copy(response.RawBody, &successPayload)
} else {
	err = json.Unmarshal(response.RawBody, &successPayload)
}
```

so the encoding/json package should be an import in all apis files.