### PR TITLE
DEVENGAGE-1658 make the unique operation ID check case-insensitive

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -4759,7 +4759,18 @@ public abstract class DefaultCodegen implements CodegenConfig {
         String uniqueName = co.operationId;
         int counter = 0;
         for (CodegenOperation op : opList) {
-            if (uniqueName.equals(op.operationId)) {
+            /* DEVENGAGE-1658 make operation ID uniqueness check case-insensitive.
+             * The example that caused this issue is:
+             *   POST /api/v2/presencedefinitions  > postPresencedefinitions
+             *   POST /api/v2/presence/definitions > postPresenceDefinitions
+             * The root cause of the issue is the OS's filesystem considering filenames only differing in casing to be
+             * equal. A generated file based on the operation ID was getting written for one casing, then the other
+             * operation with different casing overwrote the original file with new contents, but retained the original
+             * filename. So either don't use the operation ID in any filenames or make operation ID comparison
+             * case-insensitive. So here we are.
+             */
+            // Check to see if this is a known operation ID in a case-insensitive manner
+            if (uniqueName.equalsIgnoreCase(op.operationId)) {
                 uniqueName = co.operationId + "_" + counter;
                 counter++;
             }


### PR DESCRIPTION
This change makes the check for duplicate operation IDs case-insensitive to work around an issue with file systems that treat filenames in a case-insensitive manner (looking at you macos). This issue isn't present for all OSes, but we all use macs so we need to handle this case.