### PR TITLE
Fix Go SDK - Array of Uuid

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PureCloudGoClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PureCloudGoClientCodegen.java
@@ -180,6 +180,9 @@ public class PureCloudGoClientCodegen extends GoClientCodegen {
         if (property.dataType.equals("Uuid")) {
             property.dataType = "string";
         }
+        if (property.dataType.equals("[]Uuid")) {
+            property.dataType = "[]string";
+        }
     }
 
     private void markRecursiveProperties(CodegenModel cm, CodegenProperty[] lineage) {


### PR DESCRIPTION
Fix Go SDK - Array of Uuid

Swagger spec properties of (type: string, format: uuid) are already overridden/interpreted as a type string in the PureCloud Go Client generator.
This to prevent issues with type Uuid in the Platform API Go SDK.

Recently, arrays of (type: string, format: uuid) were introduced in the Swagger spec.
This update is to override/interpret them as a type []string  in the PureCloud Go Client generator and prevent issues with type Uuid in the Platform API Go SDK.
