### PR TITLE
[DEVTOOLING-1225] Fix management of enum constants starting with a digit for Java SDK

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PureCloudJavaClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PureCloudJavaClientCodegen.java
@@ -203,6 +203,33 @@ public class PureCloudJavaClientCodegen extends JavaClientCodegen {
                             }
                         }
                     }
+                } else if (cp.isArray && cp.items != null && cp.items.isEnum && cp.items.allowableValues != null) {
+                    Object valuesObject = cp.items.allowableValues.get("values");
+                    if (valuesObject != null) {
+                        ArrayList valuesArray = (ArrayList) valuesObject;
+                        if (valuesArray.get(0) instanceof Integer) {
+                            // Integer enum type
+                            valuesArray.add(0, -1);
+                            Object enumVarsObject = cp.items.allowableValues.get("enumVars");
+                            ArrayList enumVarsArray = (ArrayList) enumVarsObject;
+                            HashMap<String, String> newItem = new HashMap<>();
+                            newItem.put("name", "OUTDATEDSDKVERSION");
+                            newItem.put("value", toEnumValue("-1", "Integer"));
+                            enumVarsArray.add(0, newItem);
+                        } else {
+                            // String enum type
+                            if (!valuesArray.get(0).equals("OutdatedSdkVersion")) {
+                                valuesArray.add(0, "OutdatedSdkVersion");
+                                Object enumVarsObject = cp.items.allowableValues.get("enumVars");
+                                ArrayList enumVarsArray = (ArrayList) enumVarsObject;
+                                HashMap<String, String> newItem = new HashMap<>();
+                                newItem.put("name", "OUTDATEDSDKVERSION");
+                                newItem.put("isString", "true");
+                                newItem.put("value", toEnumValue("OutdatedSdkVersion", "String"));
+                                enumVarsArray.add(0, newItem);
+                            }
+                        }
+                    }
                 }
                 vars.add(cp);
             }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/templating/mustache/PrefixNumberWithValue.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/templating/mustache/PrefixNumberWithValue.java
@@ -35,15 +35,12 @@ public class PrefixNumberWithValue implements Mustache.Lambda {
                     line = value + line;
                 }
             } catch (Exception e) {
-                try {
-                    // Starts with a digit
-                    String first = line.substring(0, 1);
-                    Integer.parseInt(first);
+                // Check if string starts with a digit
+                if (Character.isDigit(line.charAt(0))) {
+                    // Add prefix
                     line = value + line;
-                } catch (Exception ex) {
-                    // NOOP
-                    
                 }
+                // NOOP
             }
         }
         line = line


### PR DESCRIPTION
Fix management of enum constants starting with a digit for Java SDK
i.e. "3DS" to be changed to "_3DS" constant name