### PR TITLE
[DEVTOOLING-1604] Java SDK - needs to escape operation description

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PureCloudJavaClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PureCloudJavaClientCodegen.java
@@ -129,6 +129,10 @@ public class PureCloudJavaClientCodegen extends JavaClientCodegen {
         if (operations != null) {
             List<CodegenOperation> ops = (List<CodegenOperation>) operations.get("operation");
             for (CodegenOperation operation : ops) {
+                if (operation.notes != null) {
+                    // [DEVTOOLING-1604] Escape */* in description - this interferes with javadoc comments and annotations - transforms */* -> *\\/\\*
+                    operation.notes = operation.notes.replaceAll("\\*/\\*","*\\\\\\\\/\\\\\\\\*");
+                }
                 for (CodegenParameter param : operation.allParams) {
                     Map<String, Object> allowableValues = param.allowableValues;
                     if (allowableValues != null) {


### PR DESCRIPTION
New descriptions were added in some RoutingApi endpoints (operations).
The description contains (*/*) - which is causing issue in Java comments. These need to be escaped in the openapi-generator