### PR TITLE
[DEVTOOLING-1606] Javascript SDK - needs to escape operation description

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PureCloudJavaScriptClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PureCloudJavaScriptClientCodegen.java
@@ -767,6 +767,8 @@ public class PureCloudJavaScriptClientCodegen extends DefaultCodegen implements 
                 }
                 if (operation.notes != null) {
                     operation.notes = processNotes(operation.notes);
+                    // [DEVTOOLING-1606] Escape */* in description - this interferes with javadoc comments and annotations - transforms */* -> \*\/\*
+                    operation.notes = operation.notes.replaceAll("\\*/\\*","\\\\*\\\\/\\\\*");
                 }
                 List<String> argList = new ArrayList<>();
                 boolean hasOptionalParams = false;


### PR DESCRIPTION
New descriptions were added in some RoutingApi endpoints (operations).
The description contains (\*/\*) - which is causing issue in Javascript comments. These need to be escaped in the openapi-generator